### PR TITLE
Debug macros commented out.

### DIFF
--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -34,9 +34,10 @@
 #define ADAFRUIT_MQTT_VERSION_PATCH 0
 
 // Uncomment/comment to turn on/off debug output messages.
-#define MQTT_DEBUG
+// These flags should be set in the platformio.ini file of the project!
+// #define MQTT_DEBUG
 // Uncomment/comment to turn on/off error output messages.
-#define MQTT_ERROR
+// #define MQTT_ERROR
 
 // Set where debug messages will be printed.
 #define DEBUG_PRINTER Serial


### PR DESCRIPTION
Debug macros defined in Adafruit_MQTT.h are comented now.  They now have to be defined in the platformio.ini file of your project.
